### PR TITLE
Improved "numRows" function compatibility for query with strange characters.

### DIFF
--- a/src/BridgeComponents/FetchResults.php
+++ b/src/BridgeComponents/FetchResults.php
@@ -103,8 +103,9 @@ trait FetchResults
     public function numRows(Result $result)
     {
         $query = $result->getStatement()->queryString;
+
         $countResult = $result->getConnection()->query(
-            'SELECT COUNT(*) FROM ('. $query .') AS count_table'
+            'SELECT COUNT(*) FROM ('. $query .') AS ' . uniqid('count_')
         );
 
         return (int) $countResult->fetch()[0];

--- a/src/BridgeComponents/FetchResults.php
+++ b/src/BridgeComponents/FetchResults.php
@@ -103,14 +103,9 @@ trait FetchResults
     public function numRows(Result $result)
     {
         $query = $result->getStatement()->queryString;
-        $matches = 0;
-        $count = preg_replace('~SELECT (.+) FROM~', 'SELECT COUNT(*) FROM', $query, -1, $matches);
-
-        if ($matches === 0) {
-            return 0;
-        }
-
-        $countResult = $result->getConnection()->query($count);
+        $countResult = $result->getConnection()->query(
+            'SELECT COUNT(*) FROM ('. $query .') AS count_table'
+        );
 
         return (int) $countResult->fetch()[0];
     }

--- a/test/Bridge/RowCountTest.php
+++ b/test/Bridge/RowCountTest.php
@@ -40,5 +40,12 @@ class RowCountTest extends BridgeTestCase
 
         $result = $this->bridge->query('SELECT id FROM test_table where id < 5');
         $this->assertEquals(4, $this->bridge->numRows($result));
+
+        $result = $this->bridge->query(
+            'SELECT t.*' .
+            'FROM test_table as t where id < 5'
+        );
+
+        $this->assertEquals(4, $this->bridge->numRows($result));
     }
 }


### PR DESCRIPTION
We found that for query written like this:

```
SELECT a.*, b.*, c* 
     d.*, 
     e.* FROM ...
```

`Mysql::numRows` not working correctly.

So this is the possible fix :)
