### PR TITLE
add alias mysql_numfields / mysql_numrows

### DIFF
--- a/src/globals.php
+++ b/src/globals.php
@@ -155,8 +155,20 @@ if (!function_exists('mysql_num_fields')) {
     }
 }
 
+if (!function_exists('mysql_numfields')) {
+    function mysql_numfields(Result $result) {
+        return Mysql::numFields($result);
+    }
+}
+
 if (!function_exists('mysql_num_rows')) {
     function mysql_num_rows(Result $result) {
+        return Mysql::numRows($result);
+    }
+}
+
+if (!function_exists('mysql_numrows')) {
+    function mysql_numrows(Result $result) {
         return Mysql::numRows($result);
     }
 }


### PR DESCRIPTION
improved backward compatibility - aliases mysql_numfields and mysql_numrows are deprecated but still working in PHP 5 and can occur in old projects. 